### PR TITLE
feat(card): create card variants

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,4 @@
-import {Button, Card} from "@bitwyre/ui-kit";
+import {Button, Card, CardDescription, CardHeader, CardTitle} from "@bitwyre/ui-kit";
 
 const HomePage = () => {
   return (
@@ -7,7 +7,10 @@ const HomePage = () => {
       <Button variant="link">This is Button</Button>
       <div className="mt-5 p-4">
         <Card className="p-4">
-          <p>This is Card</p>
+          <CardHeader>
+            <CardTitle>Total Assets</CardTitle>
+            <CardDescription>≈1,000,000.00 USD</CardDescription>
+          </CardHeader>
         </Card>
       </div>
     </div>

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,18 +1,29 @@
 "use client";
 
+import {VariantProps, cva} from "class-variance-authority";
 import * as React from "react";
 import {cn} from "../lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({className, ...props}, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "bg-card text-card-foreground rounded-lg border shadow-sm",
-        className,
-      )}
-      {...props}
-    />
+const cardVariants = cva("rounded-lg border", {
+  variants: {
+    variant: {
+      default: "bg-card text-card-foreground",
+      gradient:
+        "border-card-gradient-border bg-gradient-to-r from-card-gradient-start to-card-gradient-stop text-card-gradient-foreground",
+    },
+  },
+  defaultVariants: {variant: "default"},
+});
+
+export interface CardProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof cardVariants> {
+  asChild?: boolean;
+}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({className, variant, ...props}, ref) => (
+    <div ref={ref} className={cn(cardVariants({variant, className}))} {...props} />
   ),
 );
 Card.displayName = "Card";

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -4,12 +4,14 @@ import {VariantProps, cva} from "class-variance-authority";
 import * as React from "react";
 import {cn} from "../lib/utils";
 
-const cardVariants = cva("rounded-lg border", {
+const cardVariants = cva("rounded-lg", {
   variants: {
     variant: {
-      default: "bg-card text-card-foreground",
+      default: "border border-card bg-card text-card-foreground",
       gradient:
-        "border-card-gradient-border bg-gradient-to-r from-card-gradient-start to-card-gradient-stop text-card-gradient-foreground",
+        "border border-card-gradient-border bg-gradient-to-r from-card-gradient-start to-card-gradient-stop text-card-gradient-foreground",
+      "default-gradient":
+        "bg-gradient-to-br from-card to-[hsla(216,100%,51%,0.1)] text-card-foreground",
     },
   },
   defaultVariants: {variant: "default"},
@@ -34,7 +36,7 @@ const CardHeader = React.forwardRef<
 >(({className, ...props}, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-4", className)}
     {...props}
   />
 ));
@@ -57,7 +59,11 @@ const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({className, ...props}, ref) => (
-  <p ref={ref} className={cn("text-muted-foreground text-sm", className)} {...props} />
+  <p
+    ref={ref}
+    className={cn("text-primary-foreground text-sm", className)}
+    {...props}
+  />
 ));
 CardDescription.displayName = "CardDescription";
 
@@ -65,7 +71,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({className, ...props}, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 
@@ -73,7 +79,11 @@ const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({className, ...props}, ref) => (
-  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn("flex items-center gap-2.5 p-4 pt-0", className)}
+    {...props}
+  />
 ));
 CardFooter.displayName = "CardFooter";
 

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -7,8 +7,13 @@
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card: 205, 80%, 8%;
+    --card-foreground: 206, 100%, 97%;
+
+    --card-gradient-start: 220, 100%, 50%;
+    --card-gradient-stop: 258, 74%, 50%;
+    --card-gradient-foreground: 204, 11%, 91%;
+    --card-gradient-border: 206, 79%, 11%;
 
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -51,6 +51,10 @@ module.exports = {
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
+          "gradient-foreground": "hsl(var(--card-gradient-foreground))",
+          "gradient-start": "hsl(var(--card-gradient-start))",
+          "gradient-stop": "hsl(var(--card-gradient-stop))",
+          "gradient-border": "hsl(var(--card-gradient-border))",
         },
         bw: {
           "primary-blue-50": "var(--primary-blue-50)",


### PR DESCRIPTION
Create Card Component that has 3 variants:

1. `default` (default background color)
2. `gradient-default` (same as default, but with blue gradient on bottom right
3. `gradient` (has blue gradient)