### PR TITLE
feat(components/common): create common components

### DIFF
--- a/apps/docs/src/components/common.stories.tsx
+++ b/apps/docs/src/components/common.stories.tsx
@@ -1,0 +1,56 @@
+import {Box, Button, For, ShowIf} from "@bitwyre/ui-kit";
+import * as React from "react";
+
+const data = [
+  {name: "John", age: 24},
+  {name: "Adi", age: 21},
+  {name: "Hansen", age: 27},
+];
+
+export const Box_ = () => (
+  <Box as="header">
+    <p>
+      I rendered inside a box rendered as <code>header</code>
+    </p>
+  </Box>
+);
+
+export const For_ = () => (
+  <>
+    <p>
+      <code>For</code> Component
+    </p>
+
+    <ul className="list-disc list-inside">
+      <For each={data}>
+        {(item) => (
+          <li>
+            Hello, my name is {item.name}, and I am {item.age} Years old
+          </li>
+        )}
+      </For>
+    </ul>
+  </>
+);
+
+export const ShowIf_ = () => {
+  const [bool, setBool] = React.useState(true);
+  const toggleBool = () => setBool((prev) => !prev);
+
+  return (
+    <>
+      <p>
+        <code>ShowIf</code> Component
+      </p>
+      <Button variant="secondary" onClick={toggleBool}>
+        Toggle show
+      </Button>
+
+      <ShowIf
+        condition={bool}
+        fallback={<p>The condition is false, this is fallback, but optional</p>}>
+        <p>The condition is true</p>
+      </ShowIf>
+    </>
+  );
+};

--- a/apps/docs/src/components/common.stories.tsx
+++ b/apps/docs/src/components/common.stories.tsx
@@ -7,7 +7,7 @@ const data = [
   {name: "Hansen", age: 27},
 ];
 
-export const Box_ = () => (
+export const BoxComponent = () => (
   <Box as="header">
     <p>
       I rendered inside a box rendered as <code>header</code>
@@ -15,7 +15,7 @@ export const Box_ = () => (
   </Box>
 );
 
-export const For_ = () => (
+export const ForComponent = () => (
   <>
     <p>
       <code>For</code> Component
@@ -33,7 +33,7 @@ export const For_ = () => (
   </>
 );
 
-export const ShowIf_ = () => {
+export const ShowIfComponent = () => {
   const [bool, setBool] = React.useState(true);
   const toggleBool = () => setBool((prev) => !prev);
 

--- a/packages/ui/src/components/common.tsx
+++ b/packages/ui/src/components/common.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+
+export interface ShowIfProps {
+  condition: boolean;
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+/**
+ * The ShowIf component renders its children if a given condition is true, otherwise it renders a
+ * fallback component.
+ * @param {ShowIfProps}  - - `fallback`: This is a default value that will be returned if the
+ * `condition` prop is `false`.
+ * @returns If the condition is true, the children of the ShowIf component are being returned.
+ * Otherwise, the fallback value is being returned.
+ */
+const ShowIf = ({fallback = null, ...props}: ShowIfProps) =>
+  props.condition ? props.children : fallback;
+
+export interface ForProps<TData> {
+  each: Array<TData>;
+  children: (eachItem: TData, i: number) => JSX.Element;
+}
+
+/**
+ * The `For` component is a TypeScript React component that iterates over an array of data and renders
+ * child components for each item in the array.
+ * @param props - The `props` parameter is an object that contains the properties passed to the `For`
+ * component.
+ * @returns The For component is returning the result of mapping over the `props.each` array and
+ * calling the `props.children` function for each item in the array. The result is an array of React
+ * elements.
+ */
+const For = <TData,>(props: ForProps<TData>) => {
+  return React.Children.toArray(
+    props.each.map((item, itemIdx) => props.children(item, itemIdx)),
+  );
+};
+
+export type BoxProps<TElement extends React.ElementType = "div"> = {
+  as?: TElement;
+  children?: React.ReactNode;
+  defaultClassName?: string;
+} & React.HTMLProps<TElement>;
+
+/**
+ * Box Component
+ *
+ * A versatile and flexible container component that can be rendered as any HTML element.
+ *
+ * * @example
+ * // Using Box component with default "div" element:
+ * <Box defaultClassName="my-box" className="custom-box">Content</Box>
+ * // Using Box component with "section" element:
+ * <Box defaultClassName="my-box" className="custom-box" as="section">Content</Box>
+ */
+const Box = React.forwardRef(
+  <TElement extends React.ElementType = "div">(
+    {as, defaultClassName = "w-full", className, ...props}: BoxProps<TElement>,
+    ref: React.Ref<React.ElementRef<TElement>>,
+  ) => {
+    const combinedClassName = `${defaultClassName || ""} ${className ?? ""}`.trim();
+
+    return React.createElement(as ?? "div", {
+      ...props,
+      ref,
+      className: combinedClassName,
+    });
+  },
+);
+
+Box.displayName = "Box";
+
+export {Box, For, ShowIf};

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./button";
 export * from "./card";
+export * from "./common";
 export * from "./drawer";
 export * from "./input";
 export * from "./notify";


### PR DESCRIPTION
1. create `ShowIf` component
This component act like a ternary expression, accept a `condition`, `children` and `fallback`. If condition is `truthy`, the `children` wil be rendered, otherwise the `fallback` will be rendered. By default, `fallback` is optional, and will not render anything on the UI. 
3. create `For` component
Instead of manually using `Array.prototype.map` everytime we want to render a list of item on the UI and passing each `key` to it's list item, we can use this approach with `For`. `For` accept `each` props, `each` represent array of `T` on `each` item, and then the children can acces each item with function render that return `JSX.element` and we didn't have to pass `key` on each item that being rendered.
5. create `Box` component